### PR TITLE
Fix compatibility issue on modern Macs and `mkdir()` errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif # windows but MINGW_CHOST not defined
 else
 ifneq ($(OSTYPE), Darwin)
 # Normalize some abiguous ARCH strings
-ARCH ?= $(shell uname -m | sed -e 's/i.86/i386/' -e 's/amd64/x86_64/' -e 's/^arm.*/arm/')
+ARCH ?= $(shell uname -m | sed -e 's/i.86/i386/' -e 's/amd64/x86_64/' -e 's/arm64/aarch64/' -e 's/^arm.*/arm/')
 else
 ARCH ?= $(shell uname -m)
 endif
@@ -79,7 +79,7 @@ endif
 # -MMD to generate header dependencies.
 ifeq ($(OSTYPE), Darwin)
 CFLAGS := -O2 -fno-strict-aliasing -fomit-frame-pointer \
-		  -Wall -pipe -g -fwrapv -arch i386 -arch x86_64
+		  -Wall -pipe -g -fwrapv -arch $(ARCH)
 else
 CFLAGS := -O0 -fno-strict-aliasing -fomit-frame-pointer \
 		  -Wall -pipe -ggdb -MMD -fwrapv
@@ -89,7 +89,7 @@ endif
 
 # Base LDFLAGS.
 ifeq ($(OSTYPE), Darwin)
-LDFLAGS := -shared -arch i386 -arch x86_64
+LDFLAGS := -shared -arch $(ARCH)
 else
 LDFLAGS := -shared
 endif

--- a/src/g_misc.c
+++ b/src/g_misc.c
@@ -3890,15 +3890,15 @@ int PatchDeadSoldier ()
 
 	// save new model
 	sprintf (outfilename, "%s/models", gamedir->string);	// make some dirs if needed
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 	strcat (outfilename,"/deadbods");
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 	strcat (outfilename,"/dude");
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 	sprintf (outfilename, "%s/%s", gamedir->string, DEADSOLDIER_MODEL);
 	p = strstr(outfilename,"/tris.md2");
 	*p = 0;
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 
 	sprintf (outfilename, "%s/%s", gamedir->string, DEADSOLDIER_MODEL);
 

--- a/src/g_monster.c
+++ b/src/g_monster.c
@@ -1311,13 +1311,13 @@ int PatchMonsterModel (char *modelname)
 
 	// save new model
 	sprintf (outfilename, "%s/models", gamedir->string);	// make some dirs if needed
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 	strcat (outfilename,"/monsters");
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 	sprintf (outfilename, "%s/%s", gamedir->string, modelname);
 	p = strstr(outfilename,"/tris.md2");
 	*p = 0;
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 
 	sprintf (outfilename, "%s/%s", gamedir->string, modelname);
 

--- a/src/g_patchplayermodels.c
+++ b/src/g_patchplayermodels.c
@@ -133,9 +133,9 @@ int PatchPlayerModels (char *modelname)
 
 	// save new player model
 	sprintf (outfilename, "%s/players", game->string);	// make some dirs if needed
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 	sprintf (outfilename, "%s/players/%s", game->string, modelname);
-	_mkdir (outfilename);
+	mkdir (outfilename, 755);
 	sprintf (outfilename, "%s/players/%s/tris.md2", game->string, modelname);
 
 	if ( !(outfile = fopen (outfilename, "wb")) )

--- a/src/q_shared.h
+++ b/src/q_shared.h
@@ -17,6 +17,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <time.h>
 
 #if (defined _M_IX86 || defined __i386__) && !defined C_ONLY && !defined __sun__
@@ -1307,7 +1308,6 @@ FOOTSTEP_LADDER4
 #ifdef __LCC__
 #define max(a,b)    (((a) > (b)) ? (a) : (b))
 #define min(a,b)    (((a) < (b)) ? (a) : (b))
-#define _mkdir mkdir
 #endif
 
 


### PR DESCRIPTION
This PR fixes compatibility issue when compiling on Apple Silicon Macs. It also fixes some errors regarding implicit function declarations for `mkdir()` method which should fix the issue #8. I've also deleted some `_mkdir`'s definition inside the `q_shared.h` file, since it wasn't used anymore.